### PR TITLE
Add support for custom logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This package depends on `express`, `prom-client`, `express-list-endpoints`, `exp
 | urlPatternMaker  | function to create the url pattern matcher, defaults to `(path) => new UrlPattern(path, { segmentNameCharset: "a-zA-Z0-9_-" })`  |
 | normalizePath    | boolean. Set this to false to use the original url instead of cleaned up ones. |
 | createServer     | boolean. Set this to false to not create the exporter server endpoint |
+| logger           | function. Use this to pass in a custom logger function. Useful when you're using [pino](https://github.com/pinojs/pino#readme), [bunyan](https://github.com/trentm/node-bunyan#readme), [winston](https://github.com/winstonjs/winston#readme), or another custom logger. Defaults to `console.log` |
 
 ## Sample Output
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This package depends on `express`, `prom-client`, `express-list-endpoints`, `exp
 | Option Name      | Description  |
 |------------------|--------------|
 | host             | host string for the metrics server. Defaults to `127.0.0.1`  |
-| port             | port that metrics server listens on. Defaults to 9991        |
+| port             | port that metrics server listens on. Defaults to `9991`        |
 | urlPatternMaker  | function to create the url pattern matcher, defaults to `(path) => new UrlPattern(path, { segmentNameCharset: "a-zA-Z0-9_-" })`  |
 | normalizePath    | boolean. Set this to false to use the original url instead of cleaned up ones. |
 | createServer     | boolean. Set this to false to not create the exporter server endpoint |

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const setupMetricService = option => {
   const port = option.port || 9991;
 
   metricServer.listen(port, host, () => {
-    console.log(`Metrics server listening on ${host}:${port}`);
+    option.logger(`Metrics server listening on ${host}:${port}`);
   });
 };
 
@@ -36,7 +36,7 @@ const captureAllRoutes = (option, app) => {
       route.path = route.path.replace(/\/$/, "");
     }
 
-    console.log(`Route found: ${route.path}`);
+    option.logger(`Route found: ${route.path}`);
     route.pattern = route.path;
 
     // NOTE: urlPatternMaker has to create an UrlPattern compatible object.
@@ -98,6 +98,10 @@ const makeApiMiddleware = (option = {}) => {
   if (option.createServer === undefined || option.createServer) {
     setupMetricService(option);
   }
+
+  option.logger = option.logger
+    ? option.logger
+    : console.log
 
   return (req, res, next) => {
     if (allRoutes.length === 0) {


### PR DESCRIPTION
Hi there :wave: 

Thanks for making this, it's handy to drop into an Express app and I very much appreciate it.

However, I am using [pino](https://github.com/pinojs/pino#readme) as a logging framework in my Express app, and the use of `console.log` in api-express-eporter means that these logs are not ending up where I want them to.

This pull request adds support for passing in a custom logging method via the `logger` configuration option.
If no custom logger function is passed in, it defaults to `console.log` as before.

You're the boss, but I feel it's a straight-forward change, so I would appreciate if you'd consider it for inclusion.

Thank you
joost